### PR TITLE
FIX for getting the WAN IP address from a Load Balancer by using the HTTP_X_FORWARDED_FOR header when it is present

### DIFF
--- a/paynl_paymentmethods/config.xml
+++ b/paynl_paymentmethods/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>paynl_paymentmethods</name>
 	<displayName><![CDATA[Pay.nl Payment methods]]></displayName>
-	<version><![CDATA[3.3.1]]></version>
+	<version><![CDATA[3.4.4]]></version>
 	<description><![CDATA[Accept payments by Pay.nl]]></description>
 	<author><![CDATA[]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/paynl_paymentmethods/config_nl.xml
+++ b/paynl_paymentmethods/config_nl.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>paynl_paymentmethods</name>
 	<displayName><![CDATA[Pay.nl betaalmethoden]]></displayName>
-	<version><![CDATA[3.4.1]]></version>
+	<version><![CDATA[3.4.4]]></version>
 	<description><![CDATA[Acepteer betalingen via Pay.nl]]></description>
 	<author><![CDATA[]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/paynl_paymentmethods/includes/classes/Pay/Api/Start.php
+++ b/paynl_paymentmethods/includes/classes/Pay/Api/Start.php
@@ -241,8 +241,8 @@ class Pay_Api_Start extends Pay_Api {
             $data['paymentOptionSubId'] = $this->_paymentOptionSubId;
         }
 
-        
-        $data['ipAddress'] = $_SERVER['REMOTE_ADDR'];
+
+		$data['ipAddress'] = (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']);
         
         // I set the browser data with dummydata, because most servers dont have the get_browser function available
         $data['browserData'] = array(

--- a/paynl_paymentmethods/includes/classes/Pay/Api/Start.php
+++ b/paynl_paymentmethods/includes/classes/Pay/Api/Start.php
@@ -242,7 +242,7 @@ class Pay_Api_Start extends Pay_Api {
         }
 
 
-		$data['ipAddress'] = (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']);
+        $data['ipAddress'] = Tools::getRemoteAddr();
         
         // I set the browser data with dummydata, because most servers dont have the get_browser function available
         $data['browserData'] = array(

--- a/paynl_paymentmethods/paynl_paymentmethods.php
+++ b/paynl_paymentmethods/paynl_paymentmethods.php
@@ -10,7 +10,7 @@ class paynl_paymentmethods extends PaymentModule {
     public function __construct() {
         $this->name = 'paynl_paymentmethods';
         $this->tab = 'payments_gateways';
-        $this->version = '3.4.1';
+        $this->version = '3.4.4';
         $this->_postErrors = array();
 		$this->module_key = '6c2f48f238008e8f68271f5e4763d308';
 


### PR DESCRIPTION
Using the default function from PrestaShop for getting the correct IP.